### PR TITLE
gdblib: add ability to attach to an already running program

### DIFF
--- a/gdblib.go
+++ b/gdblib.go
@@ -74,13 +74,34 @@ func convertCString(cstr string) string {
 	return str
 }
 
-// NewGDB creates a new gdb debugging session. Provide the full OS path
+// NewGDBWithPID creates a new gdb debugging session.
+//  Provide the process ID of the program to debug.
+//  The source root directory is optional in order to resolve
+//  the source file references.
+func NewGDBWithPID(pid int, srcRoot string) (*GDB, error) {
+	args := []string{
+		"-p", fmt.Sprintf("%d", pid), "--interpreter", "mi2", "--nx",
+	}
+	return newGDB(args, srcRoot)
+}
+
+// NewGDB creates a new gdb debugging session.
+//  Provide the full OS path
 //  to the program to debug. The source root directory is optional in
 //  order to resolve the source file references.
 func NewGDB(program string, srcRoot string) (*GDB, error) {
+	args := []string{program, "--interpreter", "mi2", "--nx"}
+	return newGDB(args, srcRoot)
+}
+
+// newGDB creates a new gdb debugging session.
+//  Provide the arguments to the gdb process incantation.
+//  The source root directory is optional in order to resolve
+//  the source file references.
+func newGDB(cmd []string, srcRoot string) (*GDB, error) {
 	gdb := &GDB{}
 
-	gdb.gdbCmd = exec.Command("gdb", program, "--interpreter", "mi2")
+	gdb.gdbCmd = exec.Command("gdb", cmd...)
 	if srcRoot != "" {
 		gdb.gdbCmd.Dir = srcRoot
 	}

--- a/gdblib.go
+++ b/gdblib.go
@@ -80,7 +80,7 @@ func convertCString(cstr string) string {
 //  the source file references.
 func NewGDBWithPID(pid int, srcRoot string) (*GDB, error) {
 	args := []string{
-		"-p", fmt.Sprintf("%d", pid), "--interpreter", "mi2", "--nx",
+		"-p", fmt.Sprintf("%d", pid), "--interpreter", "mi2",
 	}
 	return newGDB(args, srcRoot)
 }
@@ -90,7 +90,7 @@ func NewGDBWithPID(pid int, srcRoot string) (*GDB, error) {
 //  to the program to debug. The source root directory is optional in
 //  order to resolve the source file references.
 func NewGDB(program string, srcRoot string) (*GDB, error) {
-	args := []string{program, "--interpreter", "mi2", "--nx"}
+	args := []string{program, "--interpreter", "mi2"}
 	return newGDB(args, srcRoot)
 }
 


### PR DESCRIPTION
introduce NewGDBWithPID to attach to an already running program (by PID)
refactor common parts of NewGDB and NewGDBWithPID into newGDB.
